### PR TITLE
vanilla Component implementation

### DIFF
--- a/crates/core/component/Cargo.toml
+++ b/crates/core/component/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "1.6"
 ahash = "0.8"
 rimecraft-edcode = { path = "../../util/edcode" }
 rimecraft-registry = { path = "../../util/registry", features = ["serde"] }
-rimecraft-global-cx = { path = "../global-cx" }
+rimecraft-global-cx = { path = "../global-cx", features = ["nbt", "std"] }
 rimecraft-maybe = { path = "../../util/maybe" }
 
 [features]

--- a/crates/core/component/Cargo.toml
+++ b/crates/core/component/Cargo.toml
@@ -17,7 +17,7 @@ erased-serde = "0.4"
 bytes = "1.6"
 ahash = "0.8"
 rimecraft-edcode = { path = "../../util/edcode" }
-rimecraft-registry = { path = "../../util/registry" }
+rimecraft-registry = { path = "../../util/registry", features = ["serde"] }
 rimecraft-global-cx = { path = "../global-cx" }
 rimecraft-maybe = { path = "../../util/maybe" }
 

--- a/crates/core/component/Cargo.toml
+++ b/crates/core/component/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rimecraft-component"
+version = "0.1.0"
+edition = "2021"
+authors = ["JieningYu <jiening.yu@outlook.com>"]
+description = "Minecraft Component implementation"
+repository = "https://github.com/rimecraft-rs/rimecraft/"
+license = "AGPL-3.0-or-later"
+categories = []
+
+[badges]
+maintenance = { status = "passively-maintained" }
+
+[dependencies]
+serde = "1.0"
+erased-serde = "0.4"
+bytes = "1.6"
+ahash = "0.8"
+rimecraft-edcode = { path = "../../util/edcode" }
+rimecraft-registry = { path = "../../util/registry" }
+rimecraft-global-cx = { path = "../global-cx" }
+rimecraft-maybe = { path = "../../util/maybe" }
+
+[features]
+
+[lints]
+workspace = true

--- a/crates/core/component/rime-target.toml
+++ b/crates/core/component/rime-target.toml
@@ -1,0 +1,2 @@
+[java_edition]
+version = "1.20.6"

--- a/crates/core/component/src/changes.rs
+++ b/crates/core/component/src/changes.rs
@@ -1,0 +1,128 @@
+//! `ComponentChanges` implementation.
+
+use std::{fmt::Debug, marker::PhantomData, str::FromStr};
+
+use ahash::AHashMap;
+use rimecraft_edcode::{Encode, VarI32};
+use rimecraft_global_cx::ProvideIdTy;
+use rimecraft_maybe::Maybe;
+use rimecraft_registry::{ProvideRegistry, Reg};
+use serde::{Deserialize, Serialize};
+
+use crate::{map::CompTyCell, ErasedComponentType, Object, RawErasedComponentType};
+
+/// Changes of components.
+pub struct ComponentChanges<'a, 'cow, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    pub(crate) changes: Maybe<'cow, AHashMap<CompTyCell<'a, Cx>, Option<Box<Object>>>>,
+}
+
+const REMOVED_PREFIX: char = '!';
+
+struct Type<'a, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    ty: ErasedComponentType<'a, Cx>,
+    rm: bool,
+}
+
+impl<Cx> Serialize for Type<'_, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let id = Reg::id(self.ty);
+        serializer.serialize_str(&if self.rm {
+            format!("{}{}", REMOVED_PREFIX, id)
+        } else {
+            id.to_string()
+        })
+    }
+}
+
+impl<'a, 'de, Cx> Deserialize<'de> for Type<'a, Cx>
+where
+    Cx: ProvideIdTy + ProvideRegistry<'a, Cx::Id, RawErasedComponentType<Cx>>,
+    Cx::Id: FromStr,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor<'a, Cx>
+        where
+            Cx: ProvideIdTy,
+        {
+            _marker: PhantomData<&'a Cx>,
+        }
+
+        impl<'a, Cx> serde::de::Visitor<'_> for Visitor<'a, Cx>
+        where
+            Cx: ProvideIdTy + ProvideRegistry<'a, Cx::Id, RawErasedComponentType<Cx>>,
+            Cx::Id: FromStr,
+        {
+            type Value = Type<'a, Cx>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "a string")
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let stripped = value.strip_prefix(REMOVED_PREFIX);
+                let any = stripped.unwrap_or(value);
+                let id: Cx::Id = any.parse().ok().ok_or_else(|| {
+                    E::custom(format!("unable to deserialize the identifier {}", any))
+                })?;
+
+                Ok(Type {
+                    ty: Cx::registry().get(&id).ok_or_else(|| {
+                        E::custom(format!("unable to find the component type {}", id))
+                    })?,
+                    rm: stripped.is_some(),
+                })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor {
+            _marker: PhantomData,
+        })
+    }
+}
+
+//TODO: implement encode and decode
+/*
+impl<Cx> Encode for ComponentChanges<'_, '_, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    fn encode<B>(&self, buf: B) -> Result<(), std::io::Error>
+    where
+        B: bytes::BufMut,
+    {
+        let c_valid = self.changes.iter().filter(|(_, v)| v.is_some()).count();
+        let c_rm = self.changes.len() - c_valid;
+        VarI32(c_valid as i32).encode(buf)?;
+        VarI32(c_rm as i32).encode(buf)?;
+    }
+}
+*/
+
+impl<Cx> Debug for ComponentChanges<'_, '_, Cx>
+where
+    Cx: ProvideIdTy + Debug,
+    Cx::Id: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.changes, f)
+    }
+}

--- a/crates/core/component/src/lib.rs
+++ b/crates/core/component/src/lib.rs
@@ -88,12 +88,9 @@ where
     T: Clone + Eq + Encode + Decode + Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     const SERDE_CODEC: SerdeCodec = SerdeCodec {
-        ser: |obj, serializer| {
-            erased_serde::Serialize::erased_serialize(
-                obj.downcast_ref::<T>()
-                    .expect("the erased type should matches the actual type"),
-                serializer,
-            )
+        ser: |obj| {
+            obj.downcast_ref::<T>()
+                .expect("the erased type should matches the actual type")
         },
         de: |deserializer| {
             erased_serde::deserialize::<T>(deserializer).map(|v| {
@@ -175,7 +172,7 @@ pub struct RawErasedComponentType<Cx> {
 
 #[derive(Debug)]
 struct SerdeCodec {
-    ser: fn(&Object, &mut dyn erased_serde::Serializer) -> erased_serde::Result<()>,
+    ser: for<'a> fn(&'a Object) -> &'a dyn erased_serde::Serialize,
     de: fn(&mut dyn erased_serde::Deserializer<'_>) -> erased_serde::Result<Box<Object>>,
     upd: fn(&mut Object, &mut dyn erased_serde::Deserializer<'_>) -> erased_serde::Result<()>,
 }

--- a/crates/core/component/src/lib.rs
+++ b/crates/core/component/src/lib.rs
@@ -1,0 +1,254 @@
+//! Minecraft Component implementation.
+
+use std::{
+    any::{Any, TypeId},
+    hash::Hash,
+    marker::PhantomData,
+};
+
+use rimecraft_edcode::{Decode, Encode};
+use rimecraft_global_cx::ProvideIdTy;
+use rimecraft_registry::{ProvideRegistry, Reg};
+use serde::{de::DeserializeOwned, Serialize};
+
+type Object = dyn Any + Send + Sync;
+
+pub mod map;
+
+/// Type of a component data.
+///
+/// The type `T` should be unique for each component, as it's used to identify the component.
+///
+/// For the type-erased variant, see [`RawErasedComponentType`].
+#[derive(Debug)]
+#[doc(alias = "DataComponentType")]
+pub struct ComponentType<T> {
+    serde_codec: Option<SerdeCodec>,
+    packet_codec: PacketCodec,
+    util: DynUtil,
+    _marker: PhantomData<T>,
+}
+
+impl<T> ComponentType<T> {
+    /// Returns whether the component is transient.
+    #[inline]
+    #[doc(alias = "should_skip_serialization")]
+    pub fn is_transient(&self) -> bool {
+        self.serde_codec.is_none()
+    }
+}
+
+impl<T> ComponentType<T>
+where
+    T: Clone + Eq + Send + Sync + 'static,
+{
+    const UTIL: DynUtil = DynUtil {
+        clone: |obj| Box::new(obj.downcast_ref::<T>().expect("mismatched type").clone()),
+        eq: |a, b| {
+            a.downcast_ref::<T>()
+                .zip(b.downcast_ref::<T>())
+                .map(|(a, b)| a == b)
+                .unwrap_or_default()
+        },
+    };
+}
+
+impl<T> ComponentType<T>
+where
+    T: Clone + Eq + Encode + Decode + Send + Sync + 'static,
+{
+    const PACKET_CODEC: PacketCodec = PacketCodec {
+        encode: |obj, buf| {
+            obj.downcast_ref::<T>()
+                .expect("mismatched type")
+                .encode(buf)
+        },
+        decode: |buf| Ok(Box::new(T::decode(buf)?)),
+        upd: |obj, buf| {
+            obj.downcast_mut::<T>()
+                .expect("mismatched type")
+                .decode_in_place(buf)
+        },
+    };
+
+    /// Creates a new transient component type.
+    ///
+    /// Transient components are not serialized.
+    ///
+    /// This function requires the type to be `'static`. If the type is not `'static`, transmutes
+    /// the type to `'static`, which is unsound but works.
+    #[inline]
+    pub const fn transient() -> Self {
+        Self {
+            serde_codec: None,
+            packet_codec: Self::PACKET_CODEC,
+            util: Self::UTIL,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> ComponentType<T>
+where
+    T: Clone + Eq + Encode + Decode + Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    const SERDE_CODEC: SerdeCodec = SerdeCodec {
+        ser: |obj, serializer| {
+            erased_serde::Serialize::erased_serialize(
+                obj.downcast_ref::<T>()
+                    .expect("the erased type should matches the actual type"),
+                serializer,
+            )
+        },
+        de: |deserializer| {
+            erased_serde::deserialize::<T>(deserializer).map(|v| {
+                let v: Box<Object> = Box::new(v);
+                v
+            })
+        },
+        upd: |obj, deserializer| {
+            *obj.downcast_mut::<T>()
+                .expect("the erased type should matches the actual type") =
+                erased_serde::deserialize::<T>(deserializer)?;
+            Ok(())
+        },
+    };
+
+    /// Creates a new persistent component type.
+    ///
+    /// Persistent components are serialized.
+    ///
+    /// This function requires the type to be `'static`. If the type is not `'static`, transmutes
+    /// the type to `'static`, which is unsound but works.
+    #[allow(clippy::missing_panics_doc)]
+    pub const fn persistent() -> Self {
+        Self {
+            serde_codec: Some(Self::SERDE_CODEC),
+            packet_codec: Self::PACKET_CODEC,
+            util: Self::UTIL,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static> Hash for ComponentType<T> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        TypeId::of::<T>().hash(state);
+    }
+}
+
+impl<T> PartialEq for ComponentType<T> {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> ComponentType<T> where T: Encode + Decode {}
+
+impl<T> Default for ComponentType<T>
+where
+    T: Clone + Eq + Encode + Decode + Send + Sync + 'static,
+{
+    #[inline]
+    fn default() -> Self {
+        Self::transient()
+    }
+}
+
+impl<T> Copy for ComponentType<T> {}
+
+impl<T> Clone for ComponentType<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+/// [`ComponentType`] with erased type.
+///
+/// This contains the type ID of the component and the codecs for serialization and packet encoding.
+#[derive(Debug)]
+pub struct RawErasedComponentType<Cx> {
+    ty: TypeId,
+    serde_codec: Option<SerdeCodec>,
+    packet_codec: PacketCodec,
+    util: DynUtil,
+    _marker: PhantomData<Cx>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SerdeCodec {
+    ser: fn(&Object, &mut dyn erased_serde::Serializer) -> erased_serde::Result<()>,
+    de: fn(&mut dyn erased_serde::Deserializer<'_>) -> erased_serde::Result<Box<Object>>,
+    upd: fn(&mut Object, &mut dyn erased_serde::Deserializer<'_>) -> erased_serde::Result<()>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PacketCodec {
+    encode: fn(&Object, &mut dyn bytes::BufMut) -> Result<(), std::io::Error>,
+    decode: fn(&mut dyn bytes::Buf) -> Result<Box<Object>, std::io::Error>,
+    upd: fn(&mut Object, &mut dyn bytes::Buf) -> Result<(), std::io::Error>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DynUtil {
+    clone: fn(&Object) -> Box<Object>,
+    eq: fn(&Object, &Object) -> bool,
+}
+
+impl<Cx> RawErasedComponentType<Cx> {
+    /// Downcasts this type-erased component type into a typed data component type.
+    #[inline]
+    pub fn downcast<T: 'static>(&self) -> Option<ComponentType<T>> {
+        (TypeId::of::<T>() == self.ty).then_some(ComponentType {
+            serde_codec: self.serde_codec,
+            packet_codec: self.packet_codec,
+            util: self.util,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: 'static, Cx> From<&ComponentType<T>> for RawErasedComponentType<Cx> {
+    #[inline]
+    fn from(value: &ComponentType<T>) -> Self {
+        Self {
+            ty: TypeId::of::<T>(),
+            serde_codec: value.serde_codec,
+            packet_codec: value.packet_codec,
+            util: value.util,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<Cx> Hash for RawErasedComponentType<Cx> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ty.hash(state);
+    }
+}
+
+impl<Cx> PartialEq for RawErasedComponentType<Cx> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.ty == other.ty
+    }
+}
+
+impl<Cx> Eq for RawErasedComponentType<Cx> {}
+
+impl<'r, K, Cx> ProvideRegistry<'r, K, Self> for RawErasedComponentType<Cx>
+where
+    Cx: ProvideRegistry<'r, K, Self>,
+{
+    #[inline]
+    fn registry() -> &'r rimecraft_registry::Registry<K, Self> {
+        Cx::registry()
+    }
+}
+
+/// Registration wrapper of [`RawErasedComponentType`].
+pub type ErasedComponentType<'a, Cx> = Reg<'a, <Cx as ProvideIdTy>::Id, RawErasedComponentType<Cx>>;

--- a/crates/core/component/src/map.rs
+++ b/crates/core/component/src/map.rs
@@ -10,10 +10,13 @@ use rimecraft_maybe::{Maybe, SimpleOwned};
 use rimecraft_registry::ProvideRegistry;
 use serde::{Deserialize, Serialize};
 
-use crate::{ComponentType, ErasedComponentType, Object, RawErasedComponentType, SerdeCodec};
+use crate::{
+    changes::ComponentChanges, ComponentType, ErasedComponentType, Object, RawErasedComponentType,
+    SerdeCodec,
+};
 
 #[repr(transparent)]
-struct CompTyCell<'a, Cx: ProvideIdTy>(ErasedComponentType<'a, Cx>);
+pub(crate) struct CompTyCell<'a, Cx: ProvideIdTy>(ErasedComponentType<'a, Cx>);
 
 /// A map that stores components.
 pub struct ComponentMap<'a, Cx>(MapInner<'a, Cx>)
@@ -288,6 +291,17 @@ where
     #[inline]
     pub fn iter(&self) -> Iter<'_, Cx> {
         self.into_iter()
+    }
+
+    /// Returns the changes of this map.
+    pub fn changes(&self) -> Option<ComponentChanges<'a, '_, Cx>> {
+        if let MapInner::Patched { changes, .. } = &self.0 {
+            Some(ComponentChanges {
+                changes: Maybe::Borrowed(changes),
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/core/component/src/map.rs
+++ b/crates/core/component/src/map.rs
@@ -1,0 +1,217 @@
+//! Component map implementation.
+
+use std::{any::TypeId, borrow::Borrow, hash::Hash};
+
+use ahash::AHashMap;
+use rimecraft_global_cx::ProvideIdTy;
+use rimecraft_maybe::{Maybe, SimpleOwned};
+
+use crate::{ComponentType, ErasedComponentType, Object, RawErasedComponentType};
+
+#[repr(transparent)]
+struct CompTyCell<'a, Cx: ProvideIdTy>(ErasedComponentType<'a, Cx>);
+
+pub struct ComponentMap<'a, Cx>(MapInner<'a, Cx>)
+where
+    Cx: ProvideIdTy;
+
+enum MapInner<'a, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    Empty,
+    Patched {
+        base: &'a ComponentMap<'a, Cx>,
+        changes: AHashMap<CompTyCell<'a, Cx>, Option<Box<Object>>>,
+    },
+    Simple(AHashMap<CompTyCell<'a, Cx>, Box<Object>>),
+}
+
+impl<'a, Cx> ComponentMap<'a, Cx>
+where
+    Cx: ProvideIdTy,
+{
+    /// Gets the component with given type.
+    pub fn get<T: 'static>(&self, ty: &ComponentType<T>) -> Option<&T> {
+        match &self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => changes
+                .get(&RawErasedComponentType::from(ty))
+                .map(|o| o.as_ref().and_then(|o| o.downcast_ref::<T>()))
+                .unwrap_or_else(|| base.get(ty)),
+            MapInner::Simple(map) => map
+                .get(&RawErasedComponentType::from(ty))
+                .and_then(|any| any.downcast_ref()),
+        }
+    }
+
+    #[inline]
+    fn get_raw<T: 'static>(&self, ty: &ComponentType<T>) -> Option<&Object> {
+        match &self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => changes
+                .get(&RawErasedComponentType::from(ty))
+                .map(Option::as_deref)
+                .unwrap_or_else(|| base.get_raw(ty)),
+            MapInner::Simple(map) => map.get(&RawErasedComponentType::from(ty)).map(|b| &**b),
+        }
+    }
+
+    /// Gets the component and its type registration with given type.
+    pub fn get_key_value<T: 'static>(
+        &self,
+        ty: &ComponentType<T>,
+    ) -> Option<(ErasedComponentType<'a, Cx>, &T)> {
+        match &self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => changes
+                .get_key_value(&RawErasedComponentType::from(ty))
+                .map(|(k, o)| {
+                    o.as_ref()
+                        .and_then(|o| o.downcast_ref::<T>())
+                        .map(|o| (k.0, o))
+                })
+                .unwrap_or_else(|| base.get_key_value(ty)),
+            MapInner::Simple(map) => map
+                .get_key_value(&RawErasedComponentType::from(ty))
+                .and_then(|(k, any)| any.downcast_ref().map(|a| (k.0, a))),
+        }
+    }
+
+    #[inline]
+    fn get_raw_key_value<T: 'static>(
+        &self,
+        ty: &ComponentType<T>,
+    ) -> Option<(ErasedComponentType<'a, Cx>, &Object)> {
+        match &self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => changes
+                .get_key_value(&RawErasedComponentType::from(ty))
+                .map(|(a, b)| b.as_deref().map(|b| (a.0, b)))
+                .unwrap_or_else(|| base.get_raw_key_value(ty)),
+            MapInner::Simple(map) => map
+                .get_key_value(&RawErasedComponentType::from(ty))
+                .map(|(k, any)| (k.0, &**any)),
+        }
+    }
+
+    /// Returns whether a component with given type exist.
+    pub fn contains<T: 'static>(&self, ty: &ComponentType<T>) -> bool {
+        match &self.0 {
+            MapInner::Empty => false,
+            MapInner::Patched { base, changes } => changes
+                .get(&RawErasedComponentType::from(ty))
+                .map(|opt| opt.is_some())
+                .unwrap_or_else(|| base.contains(ty)),
+            MapInner::Simple(map) => map.contains_key(&RawErasedComponentType::from(ty)),
+        }
+    }
+
+    /// Gets the component with given type, with mutable access.
+    pub fn get_mut<T: 'static>(&mut self, ty: &ComponentType<T>) -> Option<&mut T> {
+        match &mut self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => {
+                if !changes.contains_key(&RawErasedComponentType::from(ty)) {
+                    let (k, v) = base.get_raw_key_value(ty)?;
+                    changes.insert(CompTyCell(k), Some((ty.util.clone)(v)));
+                }
+                changes
+                    .get_mut(&RawErasedComponentType::from(ty))
+                    .and_then(Option::as_mut)
+                    .and_then(|obj| obj.downcast_mut::<T>())
+            }
+            MapInner::Simple(map) => map
+                .get_mut(&RawErasedComponentType::from(ty))
+                .and_then(|any| any.downcast_mut()),
+        }
+    }
+
+    /// Inserts a component into this map, and returns the old one if valid.
+    ///
+    /// This function receives a type-erased component type, because it contains the registration information,
+    /// which is useful for interacting with Minecraft protocol.
+    ///
+    /// # Panics
+    ///
+    /// This function panics when the given component type's type information does not match with
+    /// the given static type.
+    pub fn insert<T>(&mut self, ty: ErasedComponentType<'a, Cx>, val: T) -> Option<Maybe<'a, T>>
+    where
+        T: Send + Sync + 'static,
+    {
+        assert_eq! {
+            ty.ty,
+            TypeId::of::<T>(),
+            "the component type should matches the type of given value",
+        };
+        match &mut self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => {
+                let old = base.get_raw(&ty.downcast::<T>()?);
+                if old.is_some_and(|old| (ty.util.eq)(&val, old)) {
+                    changes.remove(&CompTyCell(ty))
+                } else if let Some(v) = changes.insert(CompTyCell(ty), Some(Box::new(val))) {
+                    Some(v)
+                } else {
+                    return old
+                        .and_then(|old| old.downcast_ref::<T>())
+                        .map(Maybe::Borrowed);
+                }
+                .flatten()
+            }
+            MapInner::Simple(map) => map.insert(CompTyCell(ty), Box::new(val)),
+        }
+        .and_then(|obj| obj.downcast().ok())
+        .map(|boxed| Maybe::Owned(SimpleOwned(*boxed)))
+    }
+
+    /// Removes a component with given type, and returns it if valid.
+    pub fn remove<T: 'static>(&mut self, ty: &ComponentType<T>) -> Option<Maybe<'a, T>> {
+        match &mut self.0 {
+            MapInner::Empty => None,
+            MapInner::Patched { base, changes } => {
+                let old = base.get_raw_key_value(ty);
+                let now = changes.get_mut(&RawErasedComponentType::from(ty));
+                match (old, now) {
+                    (Some((k, v)), None) => {
+                        changes.insert(CompTyCell(k), None);
+                        v.downcast_ref::<T>().map(Maybe::Borrowed)
+                    }
+                    (_, Some(now)) => now
+                        .take()
+                        .and_then(|obj| obj.downcast().ok())
+                        .map(|boxed| Maybe::Owned(SimpleOwned(*boxed))),
+                    (None, None) => None,
+                }
+            }
+            MapInner::Simple(map) => map
+                .remove(&RawErasedComponentType::from(ty))
+                .and_then(|obj| obj.downcast().ok())
+                .map(|boxed| Maybe::Owned(SimpleOwned(*boxed))),
+        }
+    }
+}
+
+impl<Cx: ProvideIdTy> PartialEq for CompTyCell<'_, Cx> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<Cx: ProvideIdTy> Eq for CompTyCell<'_, Cx> {}
+
+impl<Cx: ProvideIdTy> Hash for CompTyCell<'_, Cx> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (*self.0).hash(state)
+    }
+}
+
+impl<Cx: ProvideIdTy> Borrow<RawErasedComponentType<Cx>> for CompTyCell<'_, Cx> {
+    #[inline]
+    fn borrow(&self) -> &RawErasedComponentType<Cx> {
+        &self.0
+    }
+}

--- a/crates/core/global-cx/src/lib.rs
+++ b/crates/core/global-cx/src/lib.rs
@@ -18,7 +18,13 @@ use core::{fmt::Display, hash::Hash};
 use alloc::boxed::Box;
 
 /// Marker trait for global contexts.
-pub trait GlobalContext: Sized + 'static {}
+///
+/// # Safety
+///
+/// The type should be zero-sized, and should contains no valid instances,
+/// as it is used as a marker trait, and this guarantees that the type is
+/// FFI-safe.
+pub unsafe trait GlobalContext: Sized + 'static {}
 
 /// Marker trait for global contexts that provide an identifier type.
 pub trait ProvideIdTy: GlobalContext {
@@ -42,8 +48,8 @@ pub trait ProvideNbtTy: GlobalContext {
     fn compound_to_deserializer(compound: &Self::Compound) -> impl serde::Deserializer<'_>;
 }
 
-#[cfg(feature = "std")]
 /// NBT `edcode`-ing related marker traits.
+#[cfg(feature = "std")]
 pub mod nbt_edcode {
     use std::io;
 

--- a/crates/core/global-cx/src/lib.rs
+++ b/crates/core/global-cx/src/lib.rs
@@ -15,8 +15,6 @@ extern crate std;
 
 use core::{fmt::Display, hash::Hash};
 
-use alloc::boxed::Box;
-
 /// Marker trait for global contexts.
 ///
 /// # Safety
@@ -39,10 +37,10 @@ pub trait ProvideNbtTy: GlobalContext {
     type Compound;
 
     /// [`i32`] array type.
-    type IntArray: Into<Box<[i32]>> + From<Box<[i32]>>;
+    type IntArray: Into<alloc::boxed::Box<[i32]>> + From<alloc::boxed::Box<[i32]>>;
 
     /// [`i64`] array type.
-    type LongArray: Into<Box<[i64]>> + From<Box<[i32]>>;
+    type LongArray: Into<alloc::boxed::Box<[i64]>> + From<alloc::boxed::Box<[i32]>>;
 
     /// Function that converts a `Compound` to a [`Deserializer`].
     fn compound_to_deserializer(compound: &Self::Compound) -> impl serde::Deserializer<'_>;

--- a/crates/core/global-cx/src/lib.rs
+++ b/crates/core/global-cx/src/lib.rs
@@ -16,7 +16,6 @@ extern crate std;
 use core::{fmt::Display, hash::Hash};
 
 use alloc::boxed::Box;
-use serde::Deserializer;
 
 /// Marker trait for global contexts.
 pub trait GlobalContext: Sized + 'static {}
@@ -40,7 +39,7 @@ pub trait ProvideNbtTy: GlobalContext {
     type LongArray: Into<Box<[i64]>> + From<Box<[i32]>>;
 
     /// Function that converts a `Compound` to a [`Deserializer`].
-    fn compound_to_deserializer(compound: &Self::Compound) -> impl Deserializer<'_>;
+    fn compound_to_deserializer(compound: &Self::Compound) -> impl serde::Deserializer<'_>;
 }
 
 #[cfg(feature = "std")]

--- a/crates/util/downcast/src/lib.rs
+++ b/crates/util/downcast/src/lib.rs
@@ -69,8 +69,12 @@ where
 
 impl<T: ?Sized> Downcast<T> {
     /// Downcasts the value into a concrete type, returning an immutable reference.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it could not make sure the lifetime is safe.
     #[inline]
-    pub fn downcast_ref<V: ToStatic>(&self) -> Option<&V> {
+    pub unsafe fn downcast_ref<V: ToStatic>(&self) -> Option<&V> {
         if self.is_safe::<V>() {
             unsafe { Some(&*(&self.value as *const T as *const V)) }
         } else {
@@ -79,8 +83,12 @@ impl<T: ?Sized> Downcast<T> {
     }
 
     /// Downcasts the value into a concrete type, returning a mutable reference.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it could not make sure the lifetime is safe.
     #[inline]
-    pub fn downcast_mut<V: ToStatic>(&mut self) -> Option<&mut V> {
+    pub unsafe fn downcast_mut<V: ToStatic>(&mut self) -> Option<&mut V> {
         if self.is_safe::<V>() {
             unsafe { Some(&mut *(&mut self.value as *mut T as *mut V)) }
         } else {

--- a/crates/util/edcode/Cargo.toml
+++ b/crates/util/edcode/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["encoding"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-bytes = "1.5"
+bytes = "1.6"
 serde = { version = "1.0", optional = true }
 rimecraft-edcode-derive = { path = "../edcode-derive", optional = true }
 # custom formats
@@ -20,10 +20,10 @@ fastnbt = { version = "2.4", optional = true }
 serde_json = { version = "1.0", optional = true }
 # integrations
 uuid = { version = "1.7", optional = true }
-glam = { version = "0.25", optional = true }
+glam = { version = "0.27.0", optional = true }
 
 [features]
-# default = ["serde", "nbt", "json", "uuid", "glam"]
+# default = ["serde", "json", "uuid", "glam"]
 serde = ["dep:serde"]
 derive = ["dep:rimecraft-edcode-derive"]
 # custom formats

--- a/crates/util/maybe/src/lib.rs
+++ b/crates/util/maybe/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 
 use alloc::borrow::ToOwned;
 
@@ -29,6 +29,20 @@ where
     pub fn into_owned(self) -> Owned {
         match self {
             Maybe::Borrowed(val) => val.to_owned().into(),
+            Maybe::Owned(owned) => owned,
+        }
+    }
+
+    /// Returns a mutable reference to the owned value, cloning it if necessary.
+    pub fn get_mut(this: &mut Self) -> &mut Owned
+    where
+        Owned: DerefMut<Target = Owned>,
+    {
+        match this {
+            Maybe::Borrowed(val) => {
+                *this = Maybe::Owned(val.to_owned().into());
+                Self::get_mut(this)
+            }
             Maybe::Owned(owned) => owned,
         }
     }

--- a/crates/util/registry/src/lib.rs
+++ b/crates/util/registry/src/lib.rs
@@ -208,6 +208,12 @@ impl<'a, K, T> Reg<'a, K, T> {
     pub fn registry(this: Self) -> &'a Registry<K, T> {
         this.registry
     }
+
+    /// Gets the ID of this registration.
+    #[inline]
+    pub fn id(this: Self) -> &'a K {
+        <&RefEntry<_, _>>::from(this).key().value()
+    }
 }
 
 impl<'a, K, T> From<Reg<'a, K, T>> for &'a RefEntry<K, T> {

--- a/crates/util/serde-update/src/lib.rs
+++ b/crates/util/serde-update/src/lib.rs
@@ -26,7 +26,6 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        *self = Self::deserialize(deserializer)?;
-        Ok(())
+        serde::Deserialize::deserialize_in_place(deserializer, self)
     }
 }


### PR DESCRIPTION
In 1.20.5/1.20.6, vanilla Minecraft introduced the Component system, under `net.minecraft.component` in yarn mappings. This pull request implements it for rimecraft.

This could be an alternative of `rimecraft-attachment`, with better design in codecs.