### PR TITLE
Vanilla packet codecs implementation

### DIFF
--- a/crates/core/packet-codec/Cargo.toml
+++ b/crates/core/packet-codec/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rimecraft-packet-codec"
+version = "0.1.0"
+edition = "2021"
+authors = ["JieningYu <jiening.yu@outlook.com>"]
+description = "Encode and Decode trait for PacketCodec implementations"
+repository = "https://github.com/rimecraft-rs/rimecraft/"
+license = "AGPL-3.0-or-later"
+categories = []
+
+[badges]
+maintenance = { status = "passively-maintained" }
+
+[dependencies]
+bytes = "1.6"
+
+[features]
+
+[lints]
+workspace = true

--- a/crates/core/packet-codec/src/codecs.rs
+++ b/crates/core/packet-codec/src/codecs.rs
@@ -1,0 +1,137 @@
+//! Utilities for encoding and decoding common types.
+
+use bytes::{Buf, BufMut};
+
+use crate::{BoxedError, Decode, Encode};
+
+/// A variable-length type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Variable<T>(pub T);
+
+macro_rules! primitives {
+    ($($t:ty => $p:ident, $g:ident),*$(,)?) => {
+        $(
+        impl<B: BufMut> Encode<B> for $t {
+            #[inline]
+            fn encode(&self, mut buf: B) -> Result<(), BoxedError<'static>> {
+                buf.$p(*self);
+                Ok(())
+            }
+        }
+
+        impl<'de, B: Buf> Decode<'de, B> for $t {
+            #[inline]
+            fn decode(mut buf: B) -> Result<Self, BoxedError<'de>> {
+                Ok(buf.$g())
+            }
+        }
+        )*
+    };
+}
+
+primitives! {
+    u8 => put_u8, get_u8,
+    u16 => put_u16, get_u16,
+    u32 => put_u32, get_u32,
+    u64 => put_u64, get_u64,
+    u128 => put_u128, get_u128,
+
+    i8 => put_i8, get_i8,
+    i16 => put_i16, get_i16,
+    i32 => put_i32, get_i32,
+    i64 => put_i64, get_i64,
+    i128 => put_i128, get_i128,
+
+    f32 => put_f32, get_f32,
+    f64 => put_f64, get_f64,
+}
+
+impl<B: BufMut> Encode<B> for bool {
+    #[inline]
+    fn encode(&self, mut buf: B) -> Result<(), BoxedError<'static>> {
+        buf.put_u8(*self as u8);
+        Ok(())
+    }
+}
+
+impl<'de, B: Buf> Decode<'de, B> for bool {
+    #[inline]
+    fn decode(mut buf: B) -> Result<Self, BoxedError<'de>> {
+        Ok(buf.get_u8() != 0)
+    }
+}
+
+macro_rules! unsigned_variable_primitives {
+    ($($t:ty),*$(,)?) => {
+        type BitCount = u32;
+        const VAR_SHIFT: BitCount = u8::BITS - 1;
+
+        $(
+        #[allow(trivial_numeric_casts)]
+        impl<B: BufMut> Encode<B> for Variable<$t> {
+            fn encode(&self, mut buf: B) -> Result<(), BoxedError<'static>> {
+                let Variable(mut i) = *self;
+                while i & (<$t>::MAX << VAR_SHIFT) != 0 {
+                    buf.put_u8((i & 0b0111_1111 | 0b1000_0000) as u8);
+                    i >>= VAR_SHIFT;
+                }
+                buf.put_u8(i as u8);
+                Ok(())
+            }
+        }
+
+        #[allow(trivial_numeric_casts)]
+        impl<'de, B: Buf> Decode<'de, B> for Variable<$t> {
+            fn decode(mut buf: B) -> Result<Self, BoxedError<'de>> {
+                let mut i: $t = 0;
+                let mut shift: BitCount = 0;
+
+                loop {
+                    let b = buf.get_u8();
+                    i |= ((b & 0b0111_1111) as $t) << shift;
+                    shift += VAR_SHIFT;
+                    if shift > <$t>::BITS {
+                        return Err("variable integer too large".into());
+                    }
+                    if b & 0b1000_0000 != 0b1000_0000 {
+                        return Ok(Self(i));
+                    }
+                }
+            }
+        }
+        )*
+    };
+}
+
+unsigned_variable_primitives! {
+    u8, u16, u32, u64, u128,
+}
+
+macro_rules! signed_variable_primitives {
+    ($($s:ty => $u:ty),*$(,)?) => {
+        $(
+        impl<B: BufMut> Encode<B> for Variable<$s> {
+            #[inline]
+            fn encode(&self, buf: B) -> Result<(), BoxedError<'static>> {
+                let var = Variable(self.0 as $u);
+                var.encode(buf)
+            }
+        }
+
+        impl<'de, B: Buf> Decode<'de, B> for Variable<$s> {
+            #[inline]
+            fn decode(buf: B) -> Result<Self, BoxedError<'de>> {
+                Ok(Self(Variable::<$u>::decode(buf)?.0 as $s))
+            }
+        }
+        )*
+    };
+}
+
+signed_variable_primitives! {
+    i8 => u8,
+    i16 => u16,
+    i32 => u32,
+    i64 => u64,
+    i128 => u128,
+}

--- a/crates/core/packet-codec/src/codecs.rs
+++ b/crates/core/packet-codec/src/codecs.rs
@@ -112,7 +112,7 @@ macro_rules! unsigned_variable_primitives {
 }
 
 unsigned_variable_primitives! {
-    u8, u16, u32, u64, u128,
+    u16, u32, u64, u128, usize,
 }
 
 macro_rules! signed_variable_primitives {
@@ -137,11 +137,11 @@ macro_rules! signed_variable_primitives {
 }
 
 signed_variable_primitives! {
-    i8 => u8,
     i16 => u16,
     i32 => u32,
     i64 => u64,
     i128 => u128,
+    isize => usize,
 }
 
 impl<B: BufMut, T> Encode<B> for [T]

--- a/crates/core/packet-codec/src/codecs.rs
+++ b/crates/core/packet-codec/src/codecs.rs
@@ -98,7 +98,7 @@ macro_rules! unsigned_variable_primitives {
                     let b = buf.get_u8();
                     i |= ((b & 0b0111_1111) as $t) << shift;
                     shift += VAR_SHIFT;
-                    if shift > <$t>::BITS {
+                    if shift > <$t>::BITS + u8::BITS {
                         return Err("variable integer too large".into());
                     }
                     if b & 0b1000_0000 != 0b1000_0000 {

--- a/crates/core/packet-codec/src/lib.rs
+++ b/crates/core/packet-codec/src/lib.rs
@@ -1,0 +1,62 @@
+//! Traits for serialization and deserialization of packets.
+
+use std::marker::PhantomData;
+
+pub mod codecs;
+
+/// A boxed error type.
+pub type BoxedError<'a> = Box<dyn std::error::Error + Send + Sync + 'a>;
+
+/// Packet encoders.
+pub trait Encode<B> {
+    /// Encodes this packet into the buffer.
+    #[allow(clippy::missing_errors_doc)]
+    fn encode(&self, buf: B) -> Result<(), BoxedError<'static>>;
+}
+
+/// Packet decoders.
+pub trait Decode<'de, B>: Sized {
+    /// Decodes this packet from the buffer.
+    #[allow(clippy::missing_errors_doc)]
+    fn decode(buf: B) -> Result<Self, BoxedError<'de>>;
+}
+
+/// Packet decoders that decode in place.
+pub trait DecodeInPlace<'de, B> {
+    /// Decodes this packet from the buffer in place.
+    #[allow(clippy::missing_errors_doc)]
+    fn decode_in_place(&mut self, buf: B) -> Result<(), BoxedError<'de>>;
+}
+
+impl<'de, B, T> DecodeInPlace<'de, B> for T
+where
+    T: Decode<'de, B>,
+{
+    #[inline]
+    fn decode_in_place(&mut self, buf: B) -> Result<(), BoxedError<'de>> {
+        *self = Decode::decode(buf)?;
+        Ok(())
+    }
+}
+
+/// Packet decoders that decodes into a specified type.
+pub trait DecodeSeed<'de, B> {
+    /// The output type of the decoder.
+    type Output;
+
+    /// Decodes this packet from the buffer.
+    #[allow(clippy::missing_errors_doc)]
+    fn decode(self, buf: B) -> Result<Self::Output, BoxedError<'de>>;
+}
+
+impl<'de, B, T> DecodeSeed<'de, B> for PhantomData<T>
+where
+    T: Decode<'de, B>,
+{
+    type Output = T;
+
+    #[inline(always)]
+    fn decode(self, buf: B) -> Result<Self::Output, BoxedError<'de>> {
+        Decode::decode(buf)
+    }
+}

--- a/crates/core/packet-codec/src/lib.rs
+++ b/crates/core/packet-codec/src/lib.rs
@@ -116,3 +116,6 @@ pub trait BufExt {
 
 impl<T: BufMut + ?Sized> BufMutExt for T {}
 impl<T: Buf + ?Sized> BufExt for T {}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/packet-codec/src/lib.rs
+++ b/crates/core/packet-codec/src/lib.rs
@@ -42,6 +42,16 @@ where
     }
 }
 
+impl<B, T> Encode<B> for &T
+where
+    T: Encode<B> + ?Sized,
+{
+    #[inline(always)]
+    fn encode(&self, buf: B) -> Result<(), BoxedError<'static>> {
+        Encode::encode(*self, buf)
+    }
+}
+
 /// Packet decoders that decodes into a specified type.
 pub trait DecodeSeed<'de, B> {
     /// The output type of the decoder.

--- a/crates/core/packet-codec/src/tests.rs
+++ b/crates/core/packet-codec/src/tests.rs
@@ -1,0 +1,10 @@
+use crate::{BufExt, BufMutExt};
+
+#[test]
+fn var_long() {
+    let mut buf_mut: Vec<u8> = Vec::new();
+    const TEST_VAL: i64 = (u64::MAX - u32::MAX as u64) as i64;
+    buf_mut.put_variable(TEST_VAL);
+    let mut buf = buf_mut.as_slice();
+    assert_eq!(buf.get_variable::<i64>(), TEST_VAL);
+}

--- a/crates/util/edcode/src/lib.rs
+++ b/crates/util/edcode/src/lib.rs
@@ -1,5 +1,7 @@
 //! Encoding and decoding utilities for packet buffers.
 
+#![deprecated = "use the `rimecraft-packet-codec` crate instead"]
+
 mod imp;
 
 #[cfg(test)]


### PR DESCRIPTION
Minecraft 1.20.5/1.20.6 introduced packet codecs, which is pretty like `rimecraft-edcode`, but with differences.

This pull request re-implements it.